### PR TITLE
-Corrected Connector dragging, so that CPs are now updated during drag.

### DIFF
--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/BackingColorMapUtils.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/BackingColorMapUtils.java
@@ -46,6 +46,18 @@ public class BackingColorMapUtils
     public static void drawShapeToBacking(Context2D ctx, WiresShape shape, String color, NFastStringMap<WiresShape> m_shape_color_map)
     {
         m_shape_color_map.put(color, shape);
+        drawShapeToBacking(ctx, shape, color);
+    }
+    public static void drawShapeToBacking(Context2D ctx, WiresShape shape, String color)
+    {
+        MultiPath multiPath = shape.getPath();
+        drawShapeToBacking(ctx, shape, color, multiPath.getStrokeWidth(), true);
+
+    }
+
+    public static void drawShapeToBacking(Context2D ctx, WiresShape shape, String color, double strokeWidth, boolean fill)
+    {
+
         MultiPath multiPath = shape.getPath();
         NFastArrayList<PathPartList> listOfPaths = multiPath.getPathPartListArray();
 
@@ -53,7 +65,7 @@ public class BackingColorMapUtils
         {
             PathPartList path = listOfPaths.get(k);
 
-            ctx.setStrokeWidth(multiPath.getStrokeWidth());
+            ctx.setStrokeWidth(strokeWidth);
             ctx.setStrokeColor(color);
             ctx.setFillColor(color);
             ctx.beginPath();
@@ -112,7 +124,9 @@ public class BackingColorMapUtils
             {
                 ctx.closePath();
             }
-            ctx.fill();
+            if (fill) {
+                ctx.fill();
+            }
             ctx.stroke();
         }
     }

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/DockingAndContainmentHandler.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/DockingAndContainmentHandler.java
@@ -1,0 +1,325 @@
+/*
+   Copyright (c) 2014,2015,2016 Ahome' Innovation Technologies. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package com.ait.lienzo.client.core.shape.wires;
+
+import com.ait.lienzo.client.core.event.*;
+import com.ait.lienzo.client.core.shape.MultiPath;
+import com.ait.lienzo.client.core.shape.wires.picker.ColorMapBackedPicker;
+import com.ait.lienzo.client.core.types.BoundingBox;
+import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.lienzo.client.core.util.Geometry;
+import com.ait.lienzo.client.widget.DragConstraintEnforcer;
+import com.ait.lienzo.client.widget.DragContext;
+
+/**
+ * This class handles parent and child docking snap. For each potential parent it generates a picker image. This image consts of three layers
+ * That must be added in the correct order 1) The body. 2) The hotspot border (wider than normal border) 3) The border.
+ * The 2) hotspot is used to detect if a snap should take place and the 3) is used to check if any later (chained composite parent) adjustments
+ * would move the adjustment outside of valid snap to the border. a PickerPart is used to allow index lookup for all three different colours, to
+ * allow the x/y to asociated with the correct parts 1), 2) or 3)
+ *
+ * Drag is a simulated event, that starts on a mouse down. If it detects a drag it cancels the mouseup event. However small mouse movements can
+ * result in no drag event and still a mouse up. For this reason the code uses both drag end and mouse up events, to catch both situations.
+ *
+ * When docked the shape.dockedTo is set, it is null when not docked.
+ *
+ * There is different mouse behaviour, depending on whether the child shape starts docked or not. When it starts undocked the hotspot detection
+ * is based on the mouse x/y, when it starts docked it's based on the shape center. Once undocked it switches back to the mouse x/y.
+ */
+public class DockingAndContainmentHandler implements NodeMouseDownHandler, NodeMouseUpHandler, NodeDragEndHandler, DragConstraintEnforcer {
+
+    public static final int DOCKING_BORDER_WIDTH = 20;
+
+    private WiresShape           m_shape;
+
+    private WiresContainer       m_parent;
+
+    private WiresLayer           m_layer;
+
+    private WiresManager         m_wiresManager;
+
+    private String               m_priorFill;
+
+    private double               m_priorAlpha;
+
+    private PickerPart           m_parentPart;
+
+    private MultiPath            m_path;
+
+    private double               m_mouseStartX;
+
+    private double               m_mouseStartY;
+
+    private double               m_shapeStartCenterX;
+
+    private double               m_shapeStartCenterY;
+
+    private double               m_shapeStartX;
+
+    private double               m_shapeStartY;
+
+    private boolean              m_startDocked;
+
+    private ColorMapBackedPicker m_picker;
+
+    public DockingAndContainmentHandler(WiresShape shape, WiresManager wiresManager)
+    {
+        m_shape = shape;
+        m_wiresManager = wiresManager;
+        m_layer = m_wiresManager.getLayer();
+    }
+
+    public ColorMapBackedPicker getPicker() {
+        return m_picker;
+    }
+
+    @Override
+    public void startDrag(DragContext dragContext)
+    {
+        m_picker = new ColorMapBackedPicker(m_layer.getChildShapes(), m_layer.getLayer().getScratchPad(), m_shape, true, DOCKING_BORDER_WIDTH);
+
+        Point2D absShapeLoc =  m_shape.getPath().getAbsoluteLocation();
+        BoundingBox box = m_shape.getPath().getBoundingBox();
+        m_shapeStartX = absShapeLoc.getX();
+        m_shapeStartY = absShapeLoc.getY();
+
+        m_shapeStartCenterX = m_shapeStartX + (box.getWidth()/2);
+        m_shapeStartCenterY = m_shapeStartY + (box.getHeight()/2);
+
+        m_mouseStartX = dragContext.getDragStartX();
+        m_mouseStartY = dragContext.getDragStartY();
+
+        m_parent = m_shape.getParent();
+        if (m_parent != null && m_parent instanceof WiresShape)
+        {
+
+            if ( m_shape.getDockedTo() == null )
+            {
+                highlightBody((WiresShape) m_parent);
+                m_parentPart = new PickerPart((WiresShape) m_parent, PickerPart.ShapePart.BODY );
+            }
+            else
+            {
+                highlightBorder((WiresShape) m_parent);
+                m_parentPart = m_picker.findShapeAt((int)m_shapeStartCenterX, (int)m_shapeStartCenterY);
+                m_startDocked = true;
+            }
+            m_layer.getLayer().batch();
+            m_layer.getLayer().getOverLayer().batch();
+
+        }
+    }
+
+    @Override
+    public boolean adjust(final Point2D dxy)
+    {
+        int x = 0;
+        int y = 0;
+        if ( m_startDocked )
+        {
+            x = (int) m_shapeStartCenterX;
+            y = (int) m_shapeStartCenterY;
+        }
+        else
+        {
+            x = (int) m_mouseStartX;
+            y = (int) m_mouseStartY;
+        }
+
+        WiresContainer parent = null;
+        x = (int) (x + dxy.getX());
+        y = (int) (y + dxy.getY());
+        PickerPart parentPart = m_picker.findShapeAt(x,y);
+
+        if (parentPart != null)
+        {
+            parent = parentPart.getShape();
+        }
+
+        if (parent != m_parent || parentPart != m_parentPart)
+        {
+            boolean batch = false;
+
+            if (m_parent != null && m_parent instanceof WiresShape)
+            {
+                if ( m_parentPart != null && m_parentPart.getShapePart() == PickerPart.ShapePart.BODY ) {
+                    restoreBody();
+                } else if  (m_path != null){
+                    m_path.removeFromParent();
+                    m_path = null;
+                    m_shape.setDockedTo(null);
+                    m_startDocked = false;
+                }
+                batch = true;
+            }
+
+            if (parent != null && parent instanceof WiresShape)
+            {
+                if ( parentPart.getShapePart() == PickerPart.ShapePart.BODY )
+                {
+                    if ( parent.getContainmentAcceptor().containmentAllowed(parent, m_shape))
+                    {
+                        highlightBody((WiresShape) parent);
+                    }
+                }
+                else if ( parent.getDockingAcceptor().dockingAllowed(parent, m_shape) )
+                {
+                    highlightBorder((WiresShape) parent);
+                }
+                else
+                {
+                    // There is no valid parentPart, so null it.
+                    parentPart = null;
+                }
+                batch = true;
+            }
+
+            if (batch)
+            {
+                m_layer.getLayer().batch();
+                m_layer.getLayer().getOverLayer().batch();
+            }
+        }
+        m_parent = parent;
+        m_parentPart = parentPart;
+
+        if (m_path != null)
+        {
+            Point2D absLoc = ((WiresShape) m_parent).getGroup().getAbsoluteLocation(); // convert to local xy of the path
+            Point2D intersection = Geometry.findIntersection((int) (x - absLoc.getX()), (int) (y - absLoc.getY()), ((WiresShape) m_parent).getPath());
+            if ( intersection != null )
+            {
+                BoundingBox box = m_shape.getPath().getBoundingBox();
+
+
+                double newX = absLoc.getX() + intersection.getX() - (box.getWidth()/2);
+                double newY = absLoc.getY() + intersection.getY() - (box.getHeight()/2);
+
+                dxy.setX(newX - m_shapeStartX).setY(newY - m_shapeStartY);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void restoreBody() {
+        ((WiresShape) m_parent).getPath().setFillColor(m_priorFill);
+        ((WiresShape) m_parent).getPath().setFillAlpha(m_priorAlpha);
+    }
+
+    private void highlightBorder(WiresShape parent) {
+        MultiPath path = parent.getPath();
+        m_path = path.copy();
+        m_path.setStrokeWidth(DOCKING_BORDER_WIDTH);
+        Point2D absLoc = path.getAbsoluteLocation();
+        m_path.setX(absLoc.getX());
+        m_path.setY(absLoc.getY());
+        m_path.setStrokeColor("#CC1100");
+        m_path.setStrokeAlpha(0.8);
+        m_layer.getLayer().getOverLayer().add(m_path);
+    }
+
+    private void highlightBody(WiresShape parent)
+    {
+        m_priorFill = parent.getPath().getFillColor();
+        m_priorAlpha = parent.getPath().getFillAlpha();
+        parent.getPath().setFillColor("#CCCCCC");
+        parent.getPath().setFillAlpha(0.8);
+    }
+
+    @Override
+    public void onNodeDragEnd(NodeDragEndEvent event)
+    {
+        addShapeToParent();
+    }
+
+    @Override
+    public void onNodeMouseDown(NodeMouseDownEvent event)
+    {
+        m_parent = m_shape.getParent();
+    }
+
+    @Override
+    public void onNodeMouseUp(NodeMouseUpEvent event)
+    {
+        if (m_parent != m_shape.getParent())
+        {
+            addShapeToParent();
+        }
+    }
+
+    private void addShapeToParent()
+    {
+        Point2D absLoc = m_shape.getGroup().getAbsoluteLocation();
+
+        if (m_parent == null)
+        {
+            m_parent = m_layer;
+        }
+
+        if ( m_path != null ) {
+            m_path.removeFromParent();
+            m_layer.getLayer().getOverLayer().batch();
+        }
+
+        if ( m_parentPart == null || m_parentPart.getShapePart() == PickerPart.ShapePart.BODY ) {
+            if (m_parent.getContainmentAcceptor().acceptContainment(m_parent, m_shape)) {
+                if (m_parent instanceof WiresShape) {
+                    restoreBody();
+                }
+
+                m_shape.removeFromParent();
+
+                if (m_parent == m_layer) {
+                    m_shape.getGroup().setLocation(absLoc);
+                } else {
+                    Point2D trgAbsOffset = m_parent.getContainer().getAbsoluteLocation();
+
+                    m_shape.getGroup().setX(absLoc.getX() - trgAbsOffset.getX()).setY(absLoc.getY() - trgAbsOffset.getY());
+                }
+                m_parent.add(m_shape);
+
+                m_shape.setDockedTo(null);
+
+                m_layer.getLayer().batch();
+            }
+        }
+        else if ( m_parentPart != null &&  m_parentPart.getShapePart() != PickerPart.ShapePart.BODY &&
+                  m_parent.getDockingAcceptor().acceptDocking(m_parent, m_shape) )
+        {
+            m_shape.removeFromParent();
+
+            Point2D trgAbsOffset = m_parent.getContainer().getAbsoluteLocation();
+            m_shape.getGroup().setX(absLoc.getX() - trgAbsOffset.getX()).setY(absLoc.getY() - trgAbsOffset.getY());
+            m_parent.add(m_shape);
+
+            m_shape.setDockedTo(m_parent);
+
+            m_layer.getLayer().batch();
+        }
+        else
+        {
+            throw new IllegalStateException("Defensive Programming: Should not happen");
+        }
+
+        m_parent = null;
+        m_parentPart = null;
+        m_priorFill = null;
+        m_picker = null;
+    }
+}

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/IConnectionAcceptor.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/IConnectionAcceptor.java
@@ -18,7 +18,9 @@ package com.ait.lienzo.client.core.shape.wires;
 
 public interface IConnectionAcceptor
 {
-    static IConnectionAcceptor DEFAULT = new DefaultConnectionAcceptor();
+    static IConnectionAcceptor ALL = new DefaultConnectionAcceptor(true);
+
+    static IConnectionAcceptor NONE = new DefaultConnectionAcceptor(false);
 
     boolean acceptHead(WiresConnection head, WiresMagnet magnet);
 
@@ -30,32 +32,35 @@ public interface IConnectionAcceptor
 
     public static class DefaultConnectionAcceptor implements IConnectionAcceptor
     {
-        private DefaultConnectionAcceptor()
+        final private boolean m_defaultValue;
+
+        private DefaultConnectionAcceptor(final boolean defaultValue)
         {
+            m_defaultValue = defaultValue;
         }
 
         @Override
         public boolean tailConnectionAllowed(WiresConnection connection, WiresShape shape)
         {
-            return true;
+            return m_defaultValue;
         }
 
         @Override
         public boolean headConnectionAllowed(WiresConnection connection, WiresShape shape)
         {
-            return true;
+            return m_defaultValue;
         }
 
         @Override
         public boolean acceptHead(WiresConnection connection, WiresMagnet magnet)
         {
-            return true;
+            return m_defaultValue;
         }
 
         @Override
         public boolean acceptTail(WiresConnection connection, WiresMagnet magnet)
         {
-            return true;
+            return m_defaultValue;
         }
     }
 }

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/IContainmentAcceptor.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/IContainmentAcceptor.java
@@ -18,7 +18,9 @@ package com.ait.lienzo.client.core.shape.wires;
 
 public interface IContainmentAcceptor
 {
-    static IContainmentAcceptor DEFAULT = new DefaultContainmentAcceptor();
+    static IContainmentAcceptor ALL = new DefaultContainmentAcceptor(true);
+
+    static IContainmentAcceptor NONE = new DefaultContainmentAcceptor(false);
 
     boolean containmentAllowed(WiresContainer parent, WiresShape child);
 
@@ -26,20 +28,23 @@ public interface IContainmentAcceptor
 
     public static class DefaultContainmentAcceptor implements IContainmentAcceptor
     {
-        private DefaultContainmentAcceptor()
+        final private boolean m_defaultValue;
+
+        private DefaultContainmentAcceptor(final  boolean defaultValue)
         {
+            m_defaultValue = defaultValue;
         }
 
         @Override
         public boolean containmentAllowed(WiresContainer parent, WiresShape child)
         {
-            return true;
+            return m_defaultValue;
         }
 
         @Override
         public boolean acceptContainment(WiresContainer parent, WiresShape child)
         {
-            return true;
+            return m_defaultValue;
         }
     }
 }

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/IDockingAcceptor.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/IDockingAcceptor.java
@@ -1,22 +1,47 @@
+/*
+   Copyright (c) 2014,2015,2016 Ahome' Innovation Technologies. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
 package com.ait.lienzo.client.core.shape.wires;
 
 public interface IDockingAcceptor {
 
-    IDockingAcceptor DEFAULT = new DefaultDockingAcceptor();
+    IDockingAcceptor ALL = new DefaultDockingAcceptor(true);
 
-    boolean dockingAllowed(WiresContainer parent, WiresShape child, WiresShape target);
+    IDockingAcceptor NONE = new DefaultDockingAcceptor(false);
 
-    boolean acceptDocking(WiresContainer parent, WiresShape child, WiresShape target);
+    boolean dockingAllowed(WiresContainer parent, WiresShape child);
+
+    boolean acceptDocking(WiresContainer parent, WiresShape child);
 
     class DefaultDockingAcceptor implements IDockingAcceptor {
-        @Override
-        public boolean dockingAllowed(WiresContainer parent, WiresShape child, WiresShape target) {
-            return true;
+
+        final private boolean m_defaultValue;
+
+        public DefaultDockingAcceptor(boolean defaultValue) {
+            m_defaultValue = defaultValue;
         }
 
         @Override
-        public boolean acceptDocking(WiresContainer parent, WiresShape child, WiresShape target) {
-            return true;
+        public boolean dockingAllowed(WiresContainer parent, WiresShape child) {
+            return m_defaultValue;
+        }
+
+        @Override
+        public boolean acceptDocking(WiresContainer parent, WiresShape child) {
+            return m_defaultValue;
         }
     }
 

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/PickerPart.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/PickerPart.java
@@ -18,7 +18,7 @@ public class PickerPart
     }
 
     public enum ShapePart {
-        BORDER, BODY
+        BORDER, BORDER_HOTSPOT, BODY
     }
 
     public PickerPart(WiresShape shape, ShapePart part)

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresConnector.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresConnector.java
@@ -26,6 +26,7 @@ import com.ait.lienzo.client.core.util.ScratchPad;
 import com.ait.lienzo.client.widget.DragConstraintEnforcer;
 import com.ait.lienzo.client.widget.DragContext;
 import com.ait.lienzo.shared.core.types.ArrowEnd;
+import com.ait.lienzo.shared.core.types.EventPropagationMode;
 import com.ait.tooling.nativetools.client.collection.NFastDoubleArrayJSO;
 import com.ait.tooling.nativetools.client.collection.NFastStringMap;
 import com.ait.tooling.nativetools.client.event.HandlerRegistrationManager;
@@ -49,7 +50,7 @@ public class WiresConnector
 
     private WiresManager               m_manager;
 
-    private IConnectionAcceptor        m_connectionAcceptor = IConnectionAcceptor.DEFAULT;
+    private IConnectionAcceptor        m_connectionAcceptor = IConnectionAcceptor.ALL;
 
     public WiresConnector(AbstractDirectionalMultiPointShape<?> line, Decorator<?> head, Decorator<?> tail, WiresManager manager)
     {
@@ -62,6 +63,8 @@ public class WiresConnector
 
         // The connector decorator.
         setDecorator(line, head, tail);
+
+        m_dline.setEventPropagationMode(EventPropagationMode.FIRST_ANCESTOR);
 
         // The Line is only draggable if both Connections are unconnected
         setDraggable();
@@ -97,7 +100,6 @@ public class WiresConnector
         }
 
         m_dline = new DecoratableLine(line, head, tail);;
-        m_dline.setDraggable(isDraggable());
 
         if (head != null)
         {
@@ -668,7 +670,7 @@ public class WiresConnector
     public void setDraggable()
     {
         // The line can only be dragged if both Magnets are null
-        m_line.setDraggable(isDraggable());
+        m_dline.setDraggable(isDraggable());
     }
 
     private boolean isDraggable() {

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresConnectorDragHandler.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresConnectorDragHandler.java
@@ -26,72 +26,94 @@ import com.ait.lienzo.client.core.event.NodeMouseDownEvent;
 import com.ait.lienzo.client.core.event.NodeMouseDownHandler;
 import com.ait.lienzo.client.core.event.NodeMouseUpEvent;
 import com.ait.lienzo.client.core.event.NodeMouseUpHandler;
+import com.ait.lienzo.client.core.shape.IPrimitive;
+import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.lienzo.client.core.types.Point2DArray;
+import com.ait.tooling.nativetools.client.collection.NFastDoubleArray;
+import com.ait.tooling.nativetools.client.util.Console;
 
-public class WiresConnectorDragHandler implements NodeMouseDownHandler, NodeMouseUpHandler, NodeDragStartHandler, NodeDragMoveHandler, NodeDragEndHandler
+public class WiresConnectorDragHandler implements NodeDragStartHandler, NodeDragMoveHandler, NodeDragEndHandler
 {
     private WiresConnector m_connector;
 
-    // private WiresLayer     m_layer;
+    private WiresLayer     m_layer;
 
-    // private WiresManager   m_wiresManager;
+    private WiresManager   m_wiresManager;
 
-    private int            start_x;
-
-    private int            start_y;
+    private NFastDoubleArray m_startPoints;
 
     public WiresConnectorDragHandler(WiresConnector shape, WiresManager wiresManager)
     {
         m_connector = shape;
-        // m_wiresManager = wiresManager;
-        //m_layer = m_wiresManager.getLayer();
+        m_wiresManager = wiresManager;
+        m_layer = m_wiresManager.getLayer();
     }
 
     @Override
     public void onNodeDragStart(NodeDragStartEvent event)
     {
+        IControlHandleList handles = m_connector.getPointHandles();
 
-        start_x = event.getX();
-        start_y = event.getY();
-
+        m_startPoints = new NFastDoubleArray();
+        for (int i = 0; i < handles.size(); i++)
+        {
+            IControlHandle h = handles.getHandle(i);
+            IPrimitive<?> prim = h.getControl();
+            m_startPoints.push(prim.getX());
+            m_startPoints.push(prim.getY());
+        }
     }
 
     @Override
     public void onNodeDragMove(NodeDragMoveEvent event)
     {
+        IControlHandleList handles = m_connector.getPointHandles();
 
+        int dx = event.getDragContext().getDx();
+        int dy = event.getDragContext().getDy();
+
+        for (int i = 0, j = 0; i < handles.size(); i++, j += 2)
+        {
+            IControlHandle h = handles.getHandle(i);
+            IPrimitive<?> prim = h.getControl();
+            prim.setX( m_startPoints.get(j) + dx);
+            prim.setY( m_startPoints.get(j+1) + dy);
+        }
+
+        m_layer.getLayer().batch();
     }
 
     @Override
     public void onNodeDragEnd(NodeDragEndEvent event)
     {
 
-        final int xDiff = event.getX() - start_x;
-        final int yDiff = event.getY() - start_y;
+        m_connector.getDecoratableLine().setX(0);
+        m_connector.getDecoratableLine().setY(0);
 
-        WiresConnection headConnection = m_connector.getHeadConnection();
-        final double hx = headConnection.m_point.getX() + xDiff;
-        final double hy = headConnection.m_point.getY() + yDiff;
-        headConnection.move(hx, hy);
+        int dx = event.getDragContext().getDx();
+        int dy = event.getDragContext().getDy();
 
-        WiresConnection tailConnection = m_connector.getTailConnection();
-        final double tx = tailConnection.m_point.getX() + xDiff;
-        final double ty = tailConnection.m_point.getY() + yDiff;
-        tailConnection.move(tx, ty);
+        Point2DArray points = m_connector.getDecoratableLine().getLine().getPoint2DArray();
+        IControlHandleList handles = m_connector.getPointHandles();
 
-        m_connector.getDecoratableLine().setX(m_connector.getDecoratableLine().getX() - xDiff);
-        m_connector.getDecoratableLine().setY(m_connector.getDecoratableLine().getY() - yDiff);
+        for (int i = 0, j = 0; i < handles.size(); i++, j += 2)
+        {
+            Point2D p = points.get(i);
+            p.setX( p.getX() + dx );
+            p.setY( p.getY() + dy );
 
+            IControlHandle h = handles.getHandle(i);
+            IPrimitive<?> prim = h.getControl();
+            prim.setX( m_startPoints.get(j) + dx);
+            prim.setY( m_startPoints.get(j+1) + dy);
+        }
+
+        m_connector.getDecoratableLine().refresh();
+
+        m_layer.getLayer().batch();
+
+        m_startPoints = null;
     }
 
-    @Override
-    public void onNodeMouseDown(NodeMouseDownEvent event)
-    {
-    }
-
-    @Override
-    public void onNodeMouseUp(NodeMouseUpEvent event)
-    {
-
-    }
 
 }

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresContainer.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresContainer.java
@@ -29,8 +29,8 @@ public class WiresContainer
 
     private WiresContainer               m_parent;
 
-    private IContainmentAcceptor         m_containmentAcceptor = IContainmentAcceptor.DEFAULT;;
-    private IDockingAcceptor             m_dockingAcceptor     = IDockingAcceptor.DEFAULT;
+    private IContainmentAcceptor         m_containmentAcceptor = IContainmentAcceptor.ALL;;
+    private IDockingAcceptor             m_dockingAcceptor     = IDockingAcceptor.ALL;
 
     private WiresContainer               dockedTo;
 
@@ -72,6 +72,10 @@ public class WiresContainer
     public void setContainmentAcceptor(IContainmentAcceptor containmentAcceptor)
     {
         m_containmentAcceptor = containmentAcceptor;
+    }
+
+    public IDockingAcceptor getDockingAcceptor() {
+        return m_dockingAcceptor;
     }
 
     public void setDockingAcceptor(IDockingAcceptor dockingAcceptor)

--- a/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresShapeDragHandler.java
+++ b/src/main/java/com/ait/lienzo/client/core/shape/wires/WiresShapeDragHandler.java
@@ -18,251 +18,137 @@ package com.ait.lienzo.client.core.shape.wires;
 
 import com.ait.lienzo.client.core.event.NodeDragEndEvent;
 import com.ait.lienzo.client.core.event.NodeDragEndHandler;
-import com.ait.lienzo.client.core.event.NodeDragMoveEvent;
-import com.ait.lienzo.client.core.event.NodeDragMoveHandler;
-import com.ait.lienzo.client.core.event.NodeDragStartEvent;
-import com.ait.lienzo.client.core.event.NodeDragStartHandler;
 import com.ait.lienzo.client.core.event.NodeMouseDownEvent;
 import com.ait.lienzo.client.core.event.NodeMouseDownHandler;
 import com.ait.lienzo.client.core.event.NodeMouseUpEvent;
 import com.ait.lienzo.client.core.event.NodeMouseUpHandler;
-import com.ait.lienzo.client.core.shape.MultiPath;
-import com.ait.lienzo.client.core.shape.wires.picker.ColorMapBackedPicker;
+import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.lienzo.client.core.types.Point2D;
-import com.ait.lienzo.client.core.util.Geometry;
 import com.ait.lienzo.client.widget.DragConstraintEnforcer;
 import com.ait.lienzo.client.widget.DragContext;
-import com.ait.tooling.nativetools.client.util.Console;
+import com.ait.lienzo.client.core.shape.wires.AlignAndDistribute.AlignAndDistributeHandler;
 
-public class WiresShapeDragHandler implements NodeMouseDownHandler, NodeMouseUpHandler, NodeDragStartHandler, NodeDragMoveHandler, NodeDragEndHandler, DragConstraintEnforcer
+/**
+ * This is a composite drag handler to manage the interference of DockingAndContainmentHandler and AlignAndDistribtueHandler during snap.
+ *
+ * The DockingAndContainment snap is applied first and thus takes priority. If DockingAndContainment snap is applied, then AlignAndDistribute snap is only applied if the
+ * result is still on a point of the path. If the snap would move the point off the path, then the adjust is undone.
+ *
+ * If DockingAndContainment snap is not applied, then AlignAndDistribute can be appplied regardless.
+ */
+public class WiresShapeDragHandler implements NodeMouseDownHandler, NodeMouseUpHandler, NodeDragEndHandler, DragConstraintEnforcer
 {
-    private WiresShape                 m_shape;
+    private WiresShape                   m_shape;
 
-    private WiresContainer             m_parent;
+    private AlignAndDistributeHandler    m_alignAndDistributeHandler;
 
-    private WiresLayer                 m_layer;
+    private DockingAndContainmentHandler m_dockingAndContainmentHandler;
 
-    private WiresManager               m_wiresManager;
+    private double                       m_shapeStartX;
 
-    private String                     m_priorFill;
-
-    private double                     m_priorAlpha;
-
-    private ColorMapBackedPicker picker;
-
-    private DragContext dragContext;
+    private double                       m_shapeStartY;
 
     public WiresShapeDragHandler(WiresShape shape, WiresManager wiresManager)
     {
         m_shape = shape;
-        m_wiresManager = wiresManager;
-        m_layer = m_wiresManager.getLayer();
+    }
+
+    public void setAlignAndDistributeHandler(AlignAndDistributeHandler alignAndDistributeHandler)
+    {
+        m_alignAndDistributeHandler = alignAndDistributeHandler;
+    }
+
+    public void setDockingAndContainmentHandler(DockingAndContainmentHandler dockingAndContainmentHandler)
+    {
+        m_dockingAndContainmentHandler = dockingAndContainmentHandler;
     }
 
     @Override
-    public void onNodeDragStart(NodeDragStartEvent event)
+    public void startDrag(DragContext dragContext)
     {
-        picker = new ColorMapBackedPicker(m_layer.getLayer(), m_layer.getChildShapes(), m_layer.getLayer().getScratchPad(), m_shape, true);
 
-        m_parent = m_shape.getParent();
-        if (m_parent != null && m_parent instanceof WiresShape)
+        Point2D absShapeLoc =  m_shape.getPath().getAbsoluteLocation();
+        m_shapeStartX = absShapeLoc.getX();
+        m_shapeStartY = absShapeLoc.getY();
+
+        if ( m_dockingAndContainmentHandler != null )
         {
+            m_dockingAndContainmentHandler.startDrag(dragContext);
+        }
 
-            highlightBody((WiresShape) m_parent);
-            m_layer.getLayer().batch();
+        if ( m_alignAndDistributeHandler != null )
+        {
+            m_alignAndDistributeHandler.startDrag(dragContext);
         }
     }
-
-    private PickerPart m_parentPart;
-    private MultiPath m_path;
 
     @Override
-    public void onNodeDragMove(NodeDragMoveEvent event)
+    public boolean adjust(final Point2D dxy)
     {
-        WiresContainer parent = null;
-        PickerPart parentPart = picker.findShapeAt(event.getX(), event.getY());
 
-        if (parentPart != null)
+        boolean adjusted1 = false;
+        if ( m_dockingAndContainmentHandler != null )
         {
-            parent = parentPart.getShape();
+            adjusted1 = m_dockingAndContainmentHandler.adjust(dxy);
         }
 
-        if (parent != m_parent || parentPart != m_parentPart)
+        double dx = dxy.getX();
+        double dy = dxy.getY();
+        boolean adjusted2 = false;
+        if ( m_alignAndDistributeHandler != null && m_alignAndDistributeHandler.isDraggable())
         {
-            boolean batch = false;
+            adjusted2 = m_alignAndDistributeHandler.adjust(dxy);
+        }
 
-            if (m_parent != null && m_parent instanceof WiresShape )
+        if ( adjusted1 && adjusted2 && ( dxy.getX() != dx || dxy.getY() != dy ) )
+        {
+            BoundingBox box = m_shape.getPath().getBoundingBox();
+
+            PickerPart part = m_dockingAndContainmentHandler.getPicker().findShapeAt((int) (m_shapeStartX + dxy.getX() + (box.getWidth()/2)),
+                                                                                     (int) (m_shapeStartY + dxy.getY() + (box.getHeight()/2)));
+
+            if ( part == null || part.getShapePart() != PickerPart.ShapePart.BORDER)
             {
-                if ( m_parentPart.getShapePart() == PickerPart.ShapePart.BODY ) {
-                    restoreBody();
-                } else {
-                    m_path.removeFromParent();
-                    m_path = null;
-
-                }
-                batch = true;
-            }
-
-            if (parent != null && parent instanceof WiresShape)
-            {
-                if ( parentPart.getShapePart() == PickerPart.ShapePart.BODY )
-                {
-                    if (  parent.getContainmentAcceptor().containmentAllowed(parent, m_shape)) {
-                        highlightBody((WiresShape) parent);
-                    }
-                } else { // if ( parent.getDockingAcceptor().dockingAllowed(parent, m_shape) )
-                    highlightBorder((WiresShape) parent);
-                }
-                batch = true;
-            }
-
-            if (batch)
-            {
-                m_layer.getLayer().batch();
-                m_layer.getLayer().getOverLayer().batch();
+                dxy.setX(dx);
+                dxy.setY(dy);
+                adjusted2 = false;
             }
         }
-        m_parent = parent;
-        m_parentPart = parentPart;
-    }
 
-    private void restoreBody() {
-        ((WiresShape) m_parent).getPath().setFillColor(m_priorFill);
-        ((WiresShape) m_parent).getPath().setFillAlpha(m_priorAlpha);
-    }
-
-    private void highlightBorder(WiresShape parent) {
-        MultiPath path = parent.getPath();
-        m_path = path.copy();
-        m_path.setStrokeWidth(20);
-        Point2D absLoc = path.getAbsoluteLocation();
-        m_path.setX(absLoc.getX());
-        m_path.setY(absLoc.getY());
-        m_path.setStrokeColor("#CC1100");
-        m_path.setStrokeAlpha(0.8);
-        m_layer.getLayer().getOverLayer().add(m_path);
-    }
-
-    private void highlightBody(WiresShape parent)
-    {
-        m_priorFill = parent.getPath().getFillColor();
-        m_priorAlpha = parent.getPath().getFillAlpha();
-        parent.getPath().setFillColor("#CCCCCC");
-        parent.getPath().setFillAlpha(0.8);
+        return adjusted1 || adjusted2;
     }
 
     @Override
     public void onNodeDragEnd(NodeDragEndEvent event)
     {
-        if (m_path != null)
+        if ( m_dockingAndContainmentHandler != null )
         {
-            m_shape.setDockedTo(m_parent);
-            this.dragContext = event.getDragContext();
-            if (m_parent instanceof WiresShape) {
-                Point2D intersection = Geometry.findIntersection(event.getX(), event.getY(), ((WiresShape) m_parent).getPath());
-                if (intersection != null)
-                {
-                    Console.get().info(intersection.toJSONString());
-                    m_shape.getGroup().setX(intersection.getX()).setY(intersection.getY());
-                    m_layer.getLayer().batch();
-                    m_shape.getGroup().setDragConstraints(this);
-                }
-            }
+            m_dockingAndContainmentHandler.onNodeDragEnd(event);
         }
-        addShapeToParent();
+
+        if ( m_alignAndDistributeHandler != null )
+        {
+            m_alignAndDistributeHandler.onNodeDragEnd(event);
+        }
     }
 
     @Override
     public void onNodeMouseDown(NodeMouseDownEvent event)
     {
-        m_parent = m_shape.getParent();
+        if ( m_dockingAndContainmentHandler != null )
+        {
+            m_dockingAndContainmentHandler.onNodeMouseDown(event);
+        }
     }
 
     @Override
     public void onNodeMouseUp(NodeMouseUpEvent event)
     {
-        Console.get().info("mouseup");
-        if (m_parent != m_shape.getParent())
+        if ( m_dockingAndContainmentHandler != null )
         {
-            addShapeToParent();
-        }
-
-        if (m_path != null) {
-            Console.get().info("dropped on a border zone");
+            m_dockingAndContainmentHandler.onNodeMouseUp(event);
         }
     }
 
-    private void addShapeToParent()
-    {
-        Point2D absLoc = m_shape.getGroup().getAbsoluteLocation();
-
-        if (m_parent == null)
-        {
-            m_parent = m_layer;
-        }
-
-        if ( m_path != null ) {
-            m_path.removeFromParent();
-            m_layer.getLayer().getOverLayer().batch();
-        }
-
-        if ( m_parentPart == null || m_parentPart.getShapePart() == PickerPart.ShapePart.BODY ) {
-            if (m_parent.getContainmentAcceptor().acceptContainment(m_parent, m_shape)) {
-                if (m_parent instanceof WiresShape) {
-                    restoreBody();
-                }
-
-                m_shape.removeFromParent();
-
-                if (m_parent == m_layer) {
-                    m_shape.getGroup().setLocation(absLoc);
-                } else {
-                    Point2D trgAbsOffset = m_parent.getContainer().getAbsoluteLocation();
-
-                    m_shape.getGroup().setX(absLoc.getX() - trgAbsOffset.getX()).setY(absLoc.getY() - trgAbsOffset.getY());
-                }
-                m_parent.add(m_shape);
-
-                m_layer.getLayer().batch();
-            }
-        }
-        else // if ( parent.getDockingAcceptor().acceptDocking(parent, m_shape) )
-        {
-
-            // handle docking here
-        }
-
-        m_parent = null;
-        m_priorFill = null;
-        picker = null;
-        dragContext = null;
-    }
-
-    @Override public void startDrag(DragContext dragContext)
-    {
-        this.dragContext = dragContext;
-    }
-
-    @Override public boolean adjust(final Point2D dxy)
-    {
-        MultiPath targetShape = this.m_path;
-        if (dragContext != null && targetShape != null)
-        {
-            int x = (int) (this.dragContext.getDragStartX() + dxy.getX());
-            int y = (int) (this.dragContext.getDragStartY() + dxy.getY());
-            if (m_parent != null && m_parent instanceof WiresShape)
-            {
-                Point2D intersection = Geometry.findIntersection(x, y, ((WiresShape) m_parent).getPath());
-                if (intersection != null)
-                {
-                    Console.get().info("adjust: "+ intersection.toJSONString());
-                    double dx = intersection.getX() - this.dragContext.getDragStartX();
-                    double dy = intersection.getY() - this.dragContext.getDragStartY();
-                    dxy.setX(dx).setY(dy);
-                }
-            }
-        }
-        return false;
-    }
 
 }

--- a/src/main/java/com/ait/lienzo/client/core/util/Geometry.java
+++ b/src/main/java/com/ait/lienzo/client/core/util/Geometry.java
@@ -25,6 +25,7 @@ import com.ait.lienzo.client.core.shape.BezierCurve;
 import com.ait.lienzo.client.core.shape.IPrimitive;
 import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.QuadraticCurve;
+import com.ait.lienzo.client.core.shape.wires.WiresShape;
 import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.lienzo.client.core.types.BoundingPoints;
 import com.ait.lienzo.client.core.types.PathPartEntryJSO;
@@ -1030,6 +1031,12 @@ public final class Geometry
         final Point2DArray cardinals = getCardinals(shape.getBoundingBox());
 
         @SuppressWarnings("unchecked")
+        final Set<Point2D>[] intersections = getIntersects(shape, cardinals);
+        return removeInnerPoints(cardinals.get(0), intersections);
+    }
+
+    public static Set<Point2D>[] getIntersects(AbstractMultiPathPartShape<?> shape, Point2DArray cardinals) {
+        @SuppressWarnings("unchecked")
         final Set<Point2D>[] intersections = new Set[cardinals.size()];// c is removed, so -1
 
         final NFastArrayList<PathPartList> paths = shape.getPathPartListArray();
@@ -1040,7 +1047,7 @@ public final class Geometry
         {
             getCardinalIntersects(paths.get(i), cardinals, intersections);
         }
-        return removeInnerPoints(cardinals.get(0), intersections);
+        return intersections;
     }
 
     public static void getCardinalIntersects(PathPartList path, Point2DArray cardinals, Set<Point2D>[] intersections)
@@ -1222,7 +1229,7 @@ public final class Geometry
      */
     public static final Point2DArray getCardinals(final BoundingBox box)
     {
-        final Point2D c = new Point2D(box.getX() + box.getWidth() / 2, box.getY() + box.getHeight() / 2);
+        final Point2D c = findCenter(box);
 
         final Point2D n = new Point2D(c.getX(), box.getY());
 
@@ -1310,30 +1317,47 @@ public final class Geometry
     public static Point2D findIntersection(int x, int y, MultiPath path)
     {
         Point2D pointerPosition = new Point2D(x, y);
-        Point2D center = findCenter(path);
-        Console.get().info("c "+center.toJSONString());
-        NFastArrayList<PathPartList> pathPartListArray = path.getPathPartListArray();
-        for (int i = 0; i < pathPartListArray.size(); i++)
+        BoundingBox box = path.getBoundingBox();
+        Point2D center = findCenter(box);
+
+        // length just needs to ensure the c to xy is outside of the path
+        double length = box.getWidth()+box.getHeight();
+
+        Point2D projectionPoint = getProjection(center, pointerPosition, length);
+
+        Point2DArray points = new Point2DArray();
+        points.push(center);
+        points.push(projectionPoint);
+
+        Set<Point2D>[] intersects = Geometry.getIntersects(path, points);
+
+        Point2D nearest = null;
+        for (Set<Point2D> set : intersects)
         {
-            Point2DArray listOfLines = new Point2DArray();
-            listOfLines.push(center);
-            double length = path.getBoundingPoints().getBoundingBox().getWidth()+path.getBoundingPoints().getBoundingBox().getHeight();
-            listOfLines.push(getProjection(center, pointerPosition, length));
-            Set<Point2D>[] intersections = new Set[1];
-            getCardinalIntersects(pathPartListArray.get(i), listOfLines, intersections);
-            if (intersections.length == 2)
+            double nearesstDistance = length;
+
+            if (set != null && !set.isEmpty())
             {
-                return intersections[1].iterator().next();
+                for (Point2D p : set)
+                {
+                    double currentDistance = p.distance(pointerPosition);
+
+                    if (currentDistance < nearesstDistance)
+                    {
+                        nearesstDistance = currentDistance;
+                        nearest = p;
+                    }
+                }
             }
         }
-        return null;
+
+        return nearest;
+
     }
 
-    private static Point2D findCenter(MultiPath rect)
+    private static Point2D findCenter(BoundingBox box)
     {
-        BoundingBox box = getAbsoluteBoundingBox(rect);
-        Point2DArray cardinals = getCardinals(box);
-        return cardinals.get(0);
+        return new Point2D(box.getX() + box.getWidth() / 2, box.getY() + box.getHeight() / 2);
     }
 
     private static BoundingBox getAbsoluteBoundingBox(MultiPath rect)


### PR DESCRIPTION
-Docking now works
-Changed AlignAndDistribute to remove indexed shapes from a parent container during getBoundingBox(), otherwise a docked child moves the BB outside of the parent, and it is very confusing. They are dded back after BB is created.
-Containment and Docking needed 3 picker types in the end. Body, BorderHotspot and Border. The Border is just on top of BorderHotspot and same width of original path, it is used to control valid shapes, to ensure shape remains constrained to the line.
-Docking now has different behaviour depending on whether it starts docked or starts undocked. When undocked the xy is taken from the mouse, when docked the xy is taken from the shape center.
-Tidyups and code improvements around the color maps, to make them more generic, so they can be used by different parts of the system. Using method over-rides, to handle compatibility with existing stuff.
-Updated javadocs in various classes.
